### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,9 @@ on: [push]
 jobs:
   build:
 
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/kenpaulsen/trip-manager/security/code-scanning/1](https://github.com/kenpaulsen/trip-manager/security/code-scanning/1)

In general, to fix this problem you should explicitly declare GITHUB_TOKEN permissions in the workflow or per job, restricting them to the least privileges required (often `contents: read` for simple CI builds). This avoids inheriting potentially broad default permissions from the repository or organization.

For this specific workflow, the `build` job only checks out the code, sets up Java, and runs `mvn package`. None of these steps need to write to the repository or interact with issues/PRs. The simplest, non‑breaking fix is to add a `permissions` block with `contents: read`. You can place this either at the top level (applies to all jobs) or within the `build` job. Since CodeQL’s message focuses on the job containing `runs-on`, we’ll add it at the job level under `build:` and above `runs-on:`.

Concretely, in `.github/workflows/maven.yml`, insert:

```yaml
    permissions:
      contents: read
```

between line 7 (`build:`) and line 8 (`runs-on: ubuntu-latest`). No imports or additional methods are needed because this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
