### PR TITLE
Add unit tests for dynamo DAO classes

### DIFF
--- a/trip/src/test/java/org/paulsens/trip/dynamo/CredentialsDAOTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/CredentialsDAOTest.java
@@ -1,0 +1,227 @@
+package org.paulsens.trip.dynamo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.paulsens.trip.model.Creds;
+import org.paulsens.trip.model.Person;
+import org.paulsens.trip.util.RandomData;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class CredentialsDAOTest {
+    private CredentialsDAO dao;
+    private PersonDAO personDao;
+    private Persistence persistence;
+
+    @BeforeClass
+    public void init() {
+        FakeData.initFakeData();
+    }
+
+    @BeforeMethod
+    public void setup() {
+        final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        persistence = FakeData.createFakePersistence();
+        personDao = new PersonDAO(mapper, persistence);
+        dao = new CredentialsDAO(persistence, personDao);
+    }
+
+    @Test
+    public void getCredsByEmailAndPassReturnsNullForNullEmail() {
+        assertNull(get(dao.getCredsByEmailAndPass(null, "pass")));
+    }
+
+    @Test
+    public void getCredsByEmailAndPassReturnsNullForEmptyEmail() {
+        assertNull(get(dao.getCredsByEmailAndPass("", "pass")));
+    }
+
+    @Test
+    public void getCredsByEmailAndPassReturnsNullForNullPass() {
+        assertNull(get(dao.getCredsByEmailAndPass("user@test.com", null)));
+    }
+
+    @Test
+    public void getCredsByEmailAndPassReturnsNullForEmptyPass() {
+        assertNull(get(dao.getCredsByEmailAndPass("user@test.com", "")));
+    }
+
+    @Test
+    public void getCredsByEmailAndPassReturnsNullForBothNull() {
+        assertNull(get(dao.getCredsByEmailAndPass(null, null)));
+    }
+
+    @Test
+    public void saveAndRetrieveCreds() {
+        final List<Map<String, AttributeValue>> captured = new ArrayList<>();
+        final Persistence capturingPersistence = new Persistence() {
+            @Override
+            public CompletableFuture<PutItemResponse> putItem(Consumer<PutItemRequest.Builder> putItemRequest) {
+                final PutItemRequest.Builder builder = PutItemRequest.builder();
+                putItemRequest.accept(builder);
+                captured.add(builder.build().item());
+                return Persistence.super.putItem(putItemRequest);
+            }
+        };
+        final CredentialsDAO capturingDao = new CredentialsDAO(capturingPersistence, personDao);
+        final Person.Id userId = Person.Id.newInstance();
+        final Creds creds = new Creds("test@example.com", userId, "user", "mypass", null);
+        assertTrue(get(capturingDao.saveCreds(creds)));
+        assertEquals(captured.size(), 1);
+        final Map<String, AttributeValue> saved = captured.get(0);
+        assertEquals(saved.get("email").s(), "test@example.com");
+        assertEquals(saved.get("userId").s(), userId.getValue());
+        assertEquals(saved.get("priv").s(), "user");
+        assertEquals(saved.get("pass").s(), "mypass");
+    }
+
+    @Test
+    public void saveCredsPreservesLastLogin() {
+        final List<Map<String, AttributeValue>> captured = new ArrayList<>();
+        final Persistence capturingPersistence = new Persistence() {
+            @Override
+            public CompletableFuture<PutItemResponse> putItem(Consumer<PutItemRequest.Builder> putItemRequest) {
+                final PutItemRequest.Builder builder = PutItemRequest.builder();
+                putItemRequest.accept(builder);
+                captured.add(builder.build().item());
+                return Persistence.super.putItem(putItemRequest);
+            }
+        };
+        final CredentialsDAO capturingDao = new CredentialsDAO(capturingPersistence, personDao);
+        final long lastLogin = Instant.now().getEpochSecond();
+        final Creds creds = new Creds("login@example.com", Person.Id.newInstance(), "user", "pass", lastLogin);
+        assertTrue(get(capturingDao.saveCreds(creds)));
+        assertEquals(captured.size(), 1);
+        final Map<String, AttributeValue> saved = captured.get(0);
+        assertEquals(saved.get("lastLogin").n(), "" + lastLogin);
+    }
+
+    @Test
+    public void saveCredsWithNullLastLogin() {
+        final List<Map<String, AttributeValue>> captured = new ArrayList<>();
+        final Persistence capturingPersistence = new Persistence() {
+            @Override
+            public CompletableFuture<PutItemResponse> putItem(Consumer<PutItemRequest.Builder> putItemRequest) {
+                final PutItemRequest.Builder builder = PutItemRequest.builder();
+                putItemRequest.accept(builder);
+                captured.add(builder.build().item());
+                return Persistence.super.putItem(putItemRequest);
+            }
+        };
+        final CredentialsDAO capturingDao = new CredentialsDAO(capturingPersistence, personDao);
+        final Creds creds = new Creds("nologin@example.com", Person.Id.newInstance(), "user", "pass", null);
+        assertTrue(get(capturingDao.saveCreds(creds)));
+        assertEquals(captured.size(), 1);
+        final Map<String, AttributeValue> saved = captured.get(0);
+        assertFalse(saved.containsKey("lastLogin"), "Null lastLogin should not be stored");
+    }
+
+    @Test
+    public void updateLastLoginSetsTimestamp() {
+        final Creds creds = new Creds("update@test.com", Person.Id.newInstance(), "user", "pass", null);
+        final Long prev = dao.updateLastLogin(creds);
+        assertNull(prev);
+        assertNotNull(creds.getLastLogin());
+        assertTrue(creds.getLastLogin() > 0);
+    }
+
+    @Test
+    public void updateLastLoginReturnsPreviousValue() {
+        final long originalLogin = Instant.now().getEpochSecond() - 3600;
+        final Creds creds = new Creds("prev@test.com", Person.Id.newInstance(), "user", "pass", originalLogin);
+        final Long prev = dao.updateLastLogin(creds);
+        assertEquals(prev, Long.valueOf(originalLogin));
+        assertTrue(creds.getLastLogin() > originalLogin);
+    }
+
+    @Test
+    public void updateLastLoginWithNullCredsReturnsNull() {
+        assertNull(dao.updateLastLogin(null));
+    }
+
+    @Test
+    public void updateLastLoginSkipsSaveIfRecentLogin() {
+        final AtomicInteger putItemCount = new AtomicInteger(0);
+        final Persistence countingPersistence = new Persistence() {
+            @Override
+            public CompletableFuture<PutItemResponse> putItem(Consumer<PutItemRequest.Builder> putItemRequest) {
+                putItemCount.incrementAndGet();
+                return Persistence.super.putItem(putItemRequest);
+            }
+        };
+        final CredentialsDAO countingDao = new CredentialsDAO(countingPersistence, personDao);
+        final long recentLogin = Instant.now().getEpochSecond();
+        final Creds creds = new Creds("recent@test.com", Person.Id.newInstance(), "user", "pass", recentLogin);
+        final Long prev = countingDao.updateLastLogin(creds);
+        assertEquals(prev, Long.valueOf(recentLogin));
+        assertEquals(putItemCount.get(), 0, "Should not save when last login was within 2 seconds");
+    }
+
+    @Test
+    public void getCredsByEmailAdminOnlyReturnsNullForNullEmail() {
+        assertNull(get(dao.getCredsByEmailAdminOnly(null, Person.Id.newInstance())));
+    }
+
+    @Test
+    public void getCredsByEmailAdminOnlyReturnsNullForEmptyEmail() {
+        assertNull(get(dao.getCredsByEmailAdminOnly("", Person.Id.newInstance())));
+    }
+
+    @Test
+    public void createCredsReturnsEmptyWhenPersonNotFound() {
+        assertTrue(dao.createCreds("nonexistent@test.com").isEmpty());
+    }
+
+    @Test
+    public void createCredsSucceedsWhenPersonExists() throws Exception {
+        final String email = RandomData.genAlpha(8) + "@test.com";
+        final Person person = Person.builder().first("Cred").last("User").email(email).build();
+        get(personDao.savePerson(person));
+        final var result = dao.createCreds(email);
+        assertTrue(result.isPresent());
+        final Creds creds = result.get();
+        assertEquals(creds.getEmail(), email.toLowerCase());
+        assertEquals(creds.getUserId(), person.getId());
+        assertEquals(creds.getPriv(), Creds.USER_PRIV);
+    }
+
+    @Test
+    public void adminGetCredsByEmailReturnsNullForNullEmail() {
+        // FacesContext is null in tests, so this should return null
+        assertNull(get(dao.adminGetCredsByEmail(null)));
+    }
+
+    @Test
+    public void adminGetCredsByEmailReturnsNullForEmptyEmail() {
+        assertNull(get(dao.adminGetCredsByEmail("")));
+    }
+
+    @Test
+    public void adminGetCredsByEmailReturnsNullWithoutFacesContext() {
+        // FacesContext.getCurrentInstance() returns null in unit tests
+        assertNull(get(dao.adminGetCredsByEmail("valid@test.com")));
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/trip/src/test/java/org/paulsens/trip/dynamo/FakeDataTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/FakeDataTest.java
@@ -1,0 +1,192 @@
+package org.paulsens.trip.dynamo;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.paulsens.trip.model.Person;
+import org.paulsens.trip.model.RegistrationOption;
+import org.paulsens.trip.model.Trip;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+
+import static org.testng.Assert.*;
+
+public class FakeDataTest {
+
+    @BeforeClass
+    public void init() {
+        FakeData.initFakeData();
+    }
+
+    @Test
+    public void initFakeDataCreatesPeople() {
+        final List<Person> people = FakeData.getFakePeople();
+        assertNotNull(people);
+        assertFalse(people.isEmpty());
+    }
+
+    @Test
+    public void initFakeDataCreatesTrips() {
+        final List<Trip> trips = FakeData.getFakeTrips();
+        assertNotNull(trips);
+        assertFalse(trips.isEmpty());
+    }
+
+    @Test
+    public void fakePeopleHaveIds() {
+        for (final Person person : FakeData.getFakePeople()) {
+            assertNotNull(person.getId(), "All fake people should have IDs");
+        }
+    }
+
+    @Test
+    public void fakePeopleHaveNames() {
+        for (final Person person : FakeData.getFakePeople()) {
+            assertNotNull(person.getFirst(), "All fake people should have first names");
+            assertNotNull(person.getLast(), "All fake people should have last names");
+        }
+    }
+
+    @Test
+    public void fakeTripsHaveIds() {
+        for (final Trip trip : FakeData.getFakeTrips()) {
+            assertNotNull(trip.getId(), "All fake trips should have IDs");
+        }
+    }
+
+    @Test
+    public void fakeTripsHaveTripEvents() {
+        for (final Trip trip : FakeData.getFakeTrips()) {
+            assertFalse(trip.getTripEvents().isEmpty(),
+                    "Trip '" + trip.getTitle() + "' should have trip events");
+        }
+    }
+
+    @Test
+    public void createFakePersistenceReturnsNonNull() {
+        assertNotNull(FakeData.createFakePersistence());
+    }
+
+    @Test
+    public void fakePersistencePutItemReturnsSuccess() {
+        final Persistence p = FakeData.createFakePersistence();
+        final PutItemResponse resp = get(p.putItem(b -> b.tableName("test")));
+        assertTrue(resp.sdkHttpResponse().isSuccessful());
+    }
+
+    @Test
+    public void fakePersistenceScanReturnsEmpty() {
+        final Persistence p = FakeData.createFakePersistence();
+        final ScanResponse resp = get(p.scan(b -> b.tableName("test")));
+        assertTrue(resp.items().isEmpty());
+    }
+
+    @Test
+    public void fakePersistenceQueryReturnsEmpty() {
+        final Persistence p = FakeData.createFakePersistence();
+        final QueryResponse resp = get(p.query(b -> b.tableName("test")));
+        assertTrue(resp.items().isEmpty());
+    }
+
+    @Test
+    public void createFakePersistenceWithQueryMonitorCallsMonitor() {
+        final java.util.concurrent.atomic.AtomicInteger count = new java.util.concurrent.atomic.AtomicInteger(0);
+        final Persistence p = FakeData.createFakePersistenceWithQueryMonitor(q -> count.incrementAndGet());
+        assertEquals(count.get(), 0);
+        get(p.query(b -> b.tableName("test")));
+        assertEquals(count.get(), 1);
+        get(p.query(b -> b.tableName("test2")));
+        assertEquals(count.get(), 2);
+    }
+
+    @Test
+    public void queryMonitorPersistenceStillReturnsEmptyResults() {
+        final Persistence p = FakeData.createFakePersistenceWithQueryMonitor(q -> {});
+        final QueryResponse resp = get(p.query(b -> b.tableName("test")));
+        assertTrue(resp.items().isEmpty());
+    }
+
+    @Test
+    public void getDefaultOptionsReturnsNonEmpty() {
+        final List<RegistrationOption> options = FakeData.getDefaultOptions();
+        assertNotNull(options);
+        assertFalse(options.isEmpty());
+    }
+
+    @Test
+    public void getDefaultOptionsHaveDescriptions() {
+        for (final RegistrationOption opt : FakeData.getDefaultOptions()) {
+            assertNotNull(opt.getShortDesc(), "Option should have a short description");
+            assertNotNull(opt.getLongDesc(), "Option should have a long description");
+        }
+    }
+
+    @Test
+    public void getTestUserCredsForAdminReturnsAdminPriv() {
+        final GetItemRequest req = GetItemRequest.builder()
+                .tableName(CredentialsDAO.PASS_TABLE)
+                .key(Map.of(CredentialsDAO.EMAIL, AttributeValue.builder().s("admin123").build()))
+                .build();
+        final Map<String, AttributeValue> creds = FakeData.getTestUserCreds(req);
+        assertNotNull(creds);
+        assertEquals(creds.get(CredentialsDAO.PRIV).s(), "admin");
+    }
+
+    @Test
+    public void getTestUserCredsForUserReturnsUserPriv() {
+        final GetItemRequest req = GetItemRequest.builder()
+                .tableName(CredentialsDAO.PASS_TABLE)
+                .key(Map.of(CredentialsDAO.EMAIL, AttributeValue.builder().s("userABC").build()))
+                .build();
+        final Map<String, AttributeValue> creds = FakeData.getTestUserCreds(req);
+        assertNotNull(creds);
+        assertEquals(creds.get(CredentialsDAO.PRIV).s(), "user");
+    }
+
+    @Test
+    public void getTestUserCredsForUnknownReturnsNull() {
+        final GetItemRequest req = GetItemRequest.builder()
+                .tableName(CredentialsDAO.PASS_TABLE)
+                .key(Map.of(CredentialsDAO.EMAIL, AttributeValue.builder().s("unknown@test.com").build()))
+                .build();
+        assertNull(FakeData.getTestUserCreds(req));
+    }
+
+    @Test
+    public void getTestUserCredsEmailIsCaseInsensitive() {
+        final GetItemRequest req = GetItemRequest.builder()
+                .tableName(CredentialsDAO.PASS_TABLE)
+                .key(Map.of(CredentialsDAO.EMAIL, AttributeValue.builder().s("ADMIN_user").build()))
+                .build();
+        final Map<String, AttributeValue> creds = FakeData.getTestUserCreds(req);
+        assertNotNull(creds);
+        assertEquals(creds.get(CredentialsDAO.EMAIL).s(), "admin_user");
+    }
+
+    @Test
+    public void getTestUserCredsIncludesLastLogin() {
+        final GetItemRequest req = GetItemRequest.builder()
+                .tableName(CredentialsDAO.PASS_TABLE)
+                .key(Map.of(CredentialsDAO.EMAIL, AttributeValue.builder().s("admin").build()))
+                .build();
+        final Map<String, AttributeValue> creds = FakeData.getTestUserCreds(req);
+        assertNotNull(creds);
+        assertNotNull(creds.get(CredentialsDAO.LAST_LOGIN));
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/trip/src/test/java/org/paulsens/trip/dynamo/PersistenceTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/PersistenceTest.java
@@ -1,0 +1,152 @@
+package org.paulsens.trip.dynamo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+
+import static org.testng.Assert.*;
+
+public class PersistenceTest {
+    private final Persistence persistence = new Persistence() {};
+
+    @Test
+    public void putItemReturns200() {
+        final PutItemResponse resp = get(persistence.putItem(b -> b.tableName("test")));
+        assertEquals(resp.sdkHttpResponse().statusCode(), 200);
+        assertTrue(resp.sdkHttpResponse().isSuccessful());
+    }
+
+    @Test
+    public void scanReturnsEmptyItems() {
+        final ScanResponse resp = get(persistence.scan(b -> b.tableName("test")));
+        assertNotNull(resp.items());
+        assertTrue(resp.items().isEmpty());
+    }
+
+    @Test
+    public void queryReturnsEmptyItems() {
+        final QueryResponse resp = get(persistence.query(b -> b.tableName("test")));
+        assertNotNull(resp.items());
+        assertTrue(resp.items().isEmpty());
+    }
+
+    @Test
+    public void deleteItemReturns200() {
+        final DeleteItemResponse resp = get(persistence.deleteItem(b -> b.tableName("test")));
+        assertEquals(resp.sdkHttpResponse().statusCode(), 200);
+        assertTrue(resp.sdkHttpResponse().isSuccessful());
+    }
+
+    @Test
+    public void toStrAttrCreatesCorrectAttributeValue() {
+        final AttributeValue av = persistence.toStrAttr("hello");
+        assertEquals(av.s(), "hello");
+    }
+
+    @Test
+    public void cacheOneAddsToNonNullMap() {
+        final Map<String, String> cache = new HashMap<>();
+        cache.put("existing", "value");
+        final String result = persistence.cacheOne(cache, "newVal", "newKey", "returnMe");
+        assertEquals(result, "returnMe");
+        assertEquals(cache.get("newKey"), "newVal");
+        assertEquals(cache.size(), 2);
+    }
+
+    @Test
+    public void cacheOneHandlesNullMap() {
+        final String result = persistence.cacheOne(null, "val", "key", "returnMe");
+        assertEquals(result, "returnMe");
+    }
+
+    @Test
+    public void cacheOneReturnsPassedReturnValue() {
+        final Map<String, String> cache = new HashMap<>();
+        assertFalse(persistence.cacheOne(cache, "v", "k", false));
+        assertTrue(persistence.cacheOne(cache, "v2", "k2", true));
+    }
+
+    @Test
+    public void cacheAllClearsAndRepopulates() {
+        final Map<String, Integer> cache = new HashMap<>();
+        cache.put("old", 0);
+        final List<Integer> items = List.of(1, 2, 3);
+        final List<Integer> result = persistence.cacheAll(cache, items, i -> "key" + i);
+        assertEquals(result, items);
+        assertEquals(cache.size(), 3);
+        assertFalse(cache.containsKey("old"));
+        assertEquals(cache.get("key1"), Integer.valueOf(1));
+        assertEquals(cache.get("key2"), Integer.valueOf(2));
+        assertEquals(cache.get("key3"), Integer.valueOf(3));
+    }
+
+    @Test
+    public void cacheAllWithEmptyList() {
+        final Map<String, String> cache = new HashMap<>();
+        cache.put("old", "val");
+        persistence.cacheAll(cache, List.of(), s -> s);
+        assertTrue(cache.isEmpty());
+    }
+
+    @Test
+    public void clearCacheEventuallyClears() throws InterruptedException {
+        final Map<String, String> cache = new HashMap<>();
+        cache.put("k1", "v1");
+        cache.put("k2", "v2");
+        final boolean result = persistence.clearCache(cache, false);
+        assertFalse(result);
+        // Give the async clear time to complete (50ms delay + margin)
+        Thread.sleep(150);
+        assertTrue(cache.isEmpty());
+    }
+
+    @Test
+    public void clearCacheReturnsPassedValue() {
+        final Map<String, String> cache = new HashMap<>();
+        assertEquals(persistence.clearCache(cache, "hello"), "hello");
+        assertTrue(persistence.clearCache(cache, true));
+    }
+
+    @Test
+    public void sortListReturnsSortedCopy() {
+        final List<Integer> original = Arrays.asList(3, 1, 4, 1, 5, 9);
+        final List<Integer> sorted = persistence.sortList(original, Comparator.naturalOrder());
+        assertEquals(sorted, List.of(1, 1, 3, 4, 5, 9));
+        // Original should be unchanged
+        assertEquals(original, Arrays.asList(3, 1, 4, 1, 5, 9));
+    }
+
+    @Test
+    public void sortListWithEmptyCollection() {
+        final List<String> result = persistence.sortList(List.<String>of(), Comparator.naturalOrder());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void sortListWithCustomComparator() {
+        final List<String> items = List.of("banana", "apple", "cherry");
+        final List<String> sorted = persistence.sortList(items, Comparator.<String>reverseOrder());
+        assertEquals(sorted, List.of("cherry", "banana", "apple"));
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/trip/src/test/java/org/paulsens/trip/dynamo/PersonDAOTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/PersonDAOTest.java
@@ -1,0 +1,210 @@
+package org.paulsens.trip.dynamo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.paulsens.trip.model.Person;
+import org.paulsens.trip.util.RandomData;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class PersonDAOTest {
+    private PersonDAO dao;
+
+    @BeforeMethod
+    public void setup() {
+        dao = new PersonDAO(new ObjectMapper().findAndRegisterModules(), FakeData.createFakePersistence());
+    }
+
+    @Test
+    public void saveAndRetrievePerson() throws IOException {
+        final Person person = Person.builder()
+                .id(Person.Id.newInstance())
+                .first("Alice")
+                .last("Smith")
+                .build();
+        assertTrue(get(dao.savePerson(person)));
+        assertEquals(get(dao.getPerson(person.getId())), Optional.of(person));
+    }
+
+    @Test
+    public void getPersonWithNullIdReturnsEmpty() {
+        assertEquals(get(dao.getPerson(null)), Optional.empty());
+    }
+
+    @Test
+    public void getPeopleReturnsEmptyListInitially() {
+        final List<Person> people = get(dao.getPeople());
+        assertTrue(people.isEmpty());
+    }
+
+    @Test
+    public void getPeopleReturnsSortedList() throws IOException {
+        final Person zach = Person.builder().first("Zach").last("Zeta").build();
+        final Person alice = Person.builder().first("Alice").last("Alpha").build();
+        final Person middle = Person.builder().first("Mike").last("Middle").build();
+        get(dao.savePerson(zach));
+        get(dao.savePerson(alice));
+        get(dao.savePerson(middle));
+        final List<Person> people = get(dao.getPeople());
+        assertEquals(people.size(), 3);
+        assertEquals(people.get(0), alice);
+        assertEquals(people.get(1), middle);
+        assertEquals(people.get(2), zach);
+    }
+
+    @Test
+    public void getPeopleServesFromCache() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        final Person person = Person.builder().first("Cached").last("Person").build();
+        final AtomicInteger scanCount = new AtomicInteger(0);
+        final Persistence countingPersistence = new Persistence() {
+            @Override
+            public CompletableFuture<ScanResponse> scan(Consumer<ScanRequest.Builder> scanRequest) {
+                scanCount.incrementAndGet();
+                try {
+                    return CompletableFuture.completedFuture(ScanResponse.builder().items(List.of(
+                            Map.of("id", toStrAttr(person.getId().getValue()),
+                                    "content", toStrAttr(mapper.writeValueAsString(person)))
+                    )).build());
+                } catch (final IOException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        };
+        final PersonDAO countingDao = new PersonDAO(mapper, countingPersistence);
+        // First call triggers a scan
+        final List<Person> first = get(countingDao.getPeople());
+        assertEquals(first.size(), 1);
+        assertEquals(scanCount.get(), 1, "First call should scan");
+        // Second call should serve from cache — no additional scan
+        final List<Person> second = get(countingDao.getPeople());
+        assertEquals(second.size(), 1);
+        assertEquals(scanCount.get(), 1, "Second call should use cache, not scan again");
+    }
+
+    @Test
+    public void getPersonByEmailFindsMatch() throws IOException {
+        final String email = RandomData.genAlpha(8) + "@test.com";
+        final Person person = Person.builder().first("Test").last("User").email(email).build();
+        get(dao.savePerson(person));
+        final Person found = get(dao.getPersonByEmail(email));
+        assertEquals(found, person);
+    }
+
+    @Test
+    public void getPersonByEmailIsCaseInsensitive() throws IOException {
+        final String email = "TestUser@Example.COM";
+        final Person person = Person.builder().first("Test").last("User").email(email).build();
+        get(dao.savePerson(person));
+        final Person found = get(dao.getPersonByEmail("testuser@example.com"));
+        assertEquals(found, person);
+    }
+
+    @Test
+    public void getPersonByEmailReturnsNullWhenNotFound() throws IOException {
+        final Person person = Person.builder().first("A").last("B").email("exists@test.com").build();
+        get(dao.savePerson(person));
+        assertNull(get(dao.getPersonByEmail("nope@test.com")));
+    }
+
+    @Test
+    public void deletedPersonIsFilteredFromGetPeople() throws IOException {
+        final Person person = Person.builder().first("Del").last("Eted").build();
+        get(dao.savePerson(person));
+        assertEquals(get(dao.getPeople()).size(), 1);
+        person.delete();
+        get(dao.savePerson(person));
+        // After clearing cache, deleted person should not appear
+        dao.clearCache();
+        assertEquals(get(dao.getPeople()).size(), 0);
+    }
+
+    @Test
+    public void deletedPersonIsRemovedFromCache() throws IOException {
+        final Person person = Person.builder().first("Del").last("Eted").build();
+        get(dao.savePerson(person));
+        assertTrue(get(dao.getPerson(person.getId())).isPresent());
+        person.delete();
+        get(dao.savePerson(person));
+        // Should be gone from cache immediately
+        assertEquals(get(dao.getPerson(person.getId())), Optional.empty());
+    }
+
+    @Test
+    public void clearCacheWorks() throws IOException {
+        final Person person = Person.builder().first("Clear").last("Me").build();
+        get(dao.savePerson(person));
+        assertEquals(get(dao.getPeople()).size(), 1);
+        dao.clearCache();
+        // After clear, getPeople scans again - fake persistence returns empty
+        assertEquals(get(dao.getPeople()).size(), 0);
+    }
+
+    @Test
+    public void saveMultiplePeopleAndRetrieveIndividually() throws IOException {
+        final Person p1 = Person.builder().first("One").last("Person").build();
+        final Person p2 = Person.builder().first("Two").last("Person").build();
+        get(dao.savePerson(p1));
+        get(dao.savePerson(p2));
+        assertEquals(get(dao.getPerson(p1.getId())), Optional.of(p1));
+        assertEquals(get(dao.getPerson(p2.getId())), Optional.of(p2));
+    }
+
+    @Test
+    public void getPersonLoadsPeopleCacheOnMiss() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        final Person alice = Person.builder().id(Person.Id.from("alice")).first("Alice").last("Alpha").build();
+        final Person bob = Person.builder().id(Person.Id.from("bob")).first("Bob").last("Beta").build();
+        // Build a persistence whose scan returns both people
+        final AtomicInteger scanCount = new AtomicInteger(0);
+        final Persistence scanPersistence = new Persistence() {
+            @Override
+            public CompletableFuture<ScanResponse> scan(Consumer<ScanRequest.Builder> scanRequest) {
+                scanCount.incrementAndGet();
+                try {
+                    return CompletableFuture.completedFuture(ScanResponse.builder().items(
+                            List.of(
+                                    Map.of("id", toStrAttr(alice.getId().getValue()),
+                                            "content", toStrAttr(mapper.writeValueAsString(alice))),
+                                    Map.of("id", toStrAttr(bob.getId().getValue()),
+                                            "content", toStrAttr(mapper.writeValueAsString(bob)))
+                            )).build());
+                } catch (final IOException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        };
+        final PersonDAO scanDao = new PersonDAO(mapper, scanPersistence);
+        // Cache is empty. Request Alice — this should trigger getPeople(), loading both Alice and Bob.
+        final Optional<Person> foundAlice = get(scanDao.getPerson(Person.Id.from("alice")));
+        assertTrue(foundAlice.isPresent());
+        assertEquals(foundAlice.get().getFirst(), "Alice");
+        assertEquals(scanCount.get(), 1, "Should have scanned exactly once");
+        // Now Bob should also be in cache — no additional scan needed
+        final Optional<Person> foundBob = get(scanDao.getPerson(Person.Id.from("bob")));
+        assertTrue(foundBob.isPresent());
+        assertEquals(foundBob.get().getFirst(), "Bob");
+        assertEquals(scanCount.get(), 1, "Should still be 1 — Bob was loaded by the first scan");
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/trip/src/test/java/org/paulsens/trip/dynamo/PersonDataValueDAOTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/PersonDataValueDAOTest.java
@@ -1,0 +1,135 @@
+package org.paulsens.trip.dynamo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.paulsens.trip.model.DataId;
+import org.paulsens.trip.model.Person;
+import org.paulsens.trip.model.PersonDataValue;
+import org.paulsens.trip.util.RandomData;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class PersonDataValueDAOTest {
+    private PersonDataValueDAO dao;
+
+    @BeforeMethod
+    public void setup() {
+        dao = new PersonDataValueDAO(new ObjectMapper().findAndRegisterModules(), FakeData.createFakePersistence());
+    }
+
+    @Test
+    public void saveAndRetrievePersonDataValue() throws IOException {
+        final PersonDataValue pdv = PersonDataValue.builder()
+                .userId(Person.Id.newInstance())
+                .dataId(DataId.newInstance())
+                .type("note")
+                .content("Hello World")
+                .build();
+        assertTrue(get(dao.savePersonDataValue(pdv)));
+        final Optional<PersonDataValue> found = get(dao.getPersonDataValue(pdv.getUserId(), pdv.getDataId()));
+        assertTrue(found.isPresent());
+        assertEquals(found.get(), pdv);
+    }
+
+    @Test
+    public void getPersonDataValuesReturnsEmptyForUnknownPerson() {
+        final Map<DataId, PersonDataValue> result = get(dao.getPersonDataValues(Person.Id.newInstance()));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void getPersonDataValueReturnsEmptyForUnknownDataId() {
+        assertTrue(get(dao.getPersonDataValue(Person.Id.newInstance(), DataId.newInstance())).isEmpty());
+    }
+
+    @Test
+    public void multipleValuesForSamePerson() throws IOException {
+        final Person.Id pid = Person.Id.newInstance();
+        for (int i = 0; i < 4; i++) {
+            get(dao.savePersonDataValue(PersonDataValue.builder()
+                    .userId(pid)
+                    .dataId(DataId.newInstance())
+                    .type("type" + i)
+                    .content("content" + i)
+                    .build()));
+        }
+        assertEquals(get(dao.getPersonDataValues(pid)).size(), 4);
+    }
+
+    @Test
+    public void valuesForDifferentPeopleAreIsolated() throws IOException {
+        final Person.Id p1 = Person.Id.newInstance();
+        final Person.Id p2 = Person.Id.newInstance();
+        get(dao.savePersonDataValue(PersonDataValue.builder()
+                .userId(p1).dataId(DataId.newInstance()).type("a").content("x").build()));
+        get(dao.savePersonDataValue(PersonDataValue.builder()
+                .userId(p1).dataId(DataId.newInstance()).type("b").content("y").build()));
+        get(dao.savePersonDataValue(PersonDataValue.builder()
+                .userId(p2).dataId(DataId.newInstance()).type("c").content("z").build()));
+        assertEquals(get(dao.getPersonDataValues(p1)).size(), 2);
+        assertEquals(get(dao.getPersonDataValues(p2)).size(), 1);
+    }
+
+    @Test
+    public void saveIsIdempotent() throws IOException {
+        final Person.Id pid = Person.Id.newInstance();
+        final PersonDataValue pdv = PersonDataValue.builder()
+                .userId(pid).dataId(DataId.newInstance()).type("t").content("c").build();
+        get(dao.savePersonDataValue(pdv));
+        get(dao.savePersonDataValue(pdv));
+        assertEquals(get(dao.getPersonDataValues(pid)).size(), 1);
+    }
+
+    @Test
+    public void updateReplacesInCache() throws IOException {
+        final Person.Id pid = Person.Id.newInstance();
+        final DataId did = DataId.newInstance();
+        get(dao.savePersonDataValue(PersonDataValue.builder()
+                .userId(pid).dataId(did).type("t").content("original").build()));
+        assertEquals(get(dao.getPersonDataValue(pid, did)).get().getContent(), "original");
+        get(dao.savePersonDataValue(PersonDataValue.builder()
+                .userId(pid).dataId(did).type("t").content("updated").build()));
+        assertEquals(get(dao.getPersonDataValue(pid, did)).get().getContent(), "updated");
+    }
+
+    @Test
+    public void clearCacheWorks() throws IOException {
+        final Person.Id pid = Person.Id.newInstance();
+        get(dao.savePersonDataValue(PersonDataValue.builder()
+                .userId(pid).dataId(DataId.newInstance()).type("t").content("c").build()));
+        assertEquals(get(dao.getPersonDataValues(pid)).size(), 1);
+        dao.clearCache();
+        assertEquals(get(dao.getPersonDataValues(pid)).size(), 0);
+    }
+
+    @Test
+    public void complexContentIsPreserved() throws IOException {
+        final Map<String, String> content = Map.of("key1", "val1", "key2", "val2");
+        final PersonDataValue pdv = PersonDataValue.builder()
+                .userId(Person.Id.newInstance())
+                .dataId(DataId.newInstance())
+                .type("map")
+                .content(content)
+                .build();
+        get(dao.savePersonDataValue(pdv));
+        final PersonDataValue found = get(dao.getPersonDataValue(pdv.getUserId(), pdv.getDataId())).orElse(null);
+        assertNotNull(found);
+        assertEquals(found.getContent(), content);
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/trip/src/test/java/org/paulsens/trip/dynamo/PrivilegesDAOTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/PrivilegesDAOTest.java
@@ -1,23 +1,113 @@
 package org.paulsens.trip.dynamo;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.paulsens.trip.model.Person;
 import org.paulsens.trip.model.Privilege;
 import org.paulsens.trip.util.RandomData;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
 public class PrivilegesDAOTest {
+    private PrivilegesDAO dao;
+
+    @BeforeClass
+    public void init() {
+        FakeData.initFakeData();
+    }
+
+    @BeforeMethod
+    public void setup() {
+        dao = new PrivilegesDAO(new ObjectMapper().findAndRegisterModules(), FakeData.createFakePersistence());
+    }
 
     @Test
-    public void canGetAndSavePrivilege() throws Exception {
-        final PrivilegesDAO dao = new PrivilegesDAO(DAO.getInstance().getMapper(), FakeData.createFakePersistence());
+    public void canGetAndSavePrivilege() {
         final Privilege priv = getTestPriv();
-        assertTrue(dao.getPrivilege(priv.getName()).get(1_000, TimeUnit.MILLISECONDS).isEmpty());
-        assertTrue(dao.savePrivilege(priv).get(1_000, TimeUnit.MILLISECONDS));
-        assertEquals(dao.getPrivilege(priv.getName()).get(1_000, TimeUnit.MILLISECONDS).get(), priv);
+        assertTrue(get(dao.getPrivilege(priv.getName())).isEmpty());
+        assertTrue(get(dao.savePrivilege(priv)));
+        assertEquals(get(dao.getPrivilege(priv.getName())).get(), priv);
+    }
+
+    @Test
+    public void getPrivilegeReturnsEmptyForUnknown() {
+        assertTrue(get(dao.getPrivilege("nonexistent-" + RandomData.genAlpha(10))).isEmpty());
+    }
+
+    @Test
+    public void saveAndRetrieveMultiplePrivileges() {
+        final Privilege p1 = new Privilege("alpha-" + RandomData.genAlpha(5), "desc1", List.of());
+        final Privilege p2 = new Privilege("beta-" + RandomData.genAlpha(5), "desc2", List.of());
+        get(dao.savePrivilege(p1));
+        get(dao.savePrivilege(p2));
+        assertEquals(get(dao.getPrivilege(p1.getName())), Optional.of(p1));
+        assertEquals(get(dao.getPrivilege(p2.getName())), Optional.of(p2));
+    }
+
+    @Test
+    public void getPrivilegesReturnsEmptyInitially() {
+        final List<Privilege> privs = get(dao.getPrivileges());
+        assertTrue(privs.isEmpty());
+    }
+
+    @Test
+    public void getPrivilegesReturnsSortedByName() {
+        // First call getPrivileges to trigger the initial scan (returns empty from fake persistence)
+        // This sets hasScanned=true, so subsequent getPrivileges calls use the cache
+        get(dao.getPrivileges());
+        // Now saves will add to the non-empty cache (cacheOne only adds when cache is non-empty,
+        // but after the scan, the cache map object exists even if empty, so we need to seed it)
+        // savePrivilege uses cacheOne which requires a non-null cache, but won't add to completely empty map
+        // because the cache pattern checks if the cache map is non-empty first.
+        // Instead, we test via getPrivilege (which does a direct getItem lookup)
+        get(dao.savePrivilege(new Privilege("Zebra", "z", List.of())));
+        get(dao.savePrivilege(new Privilege("Alpha", "a", List.of())));
+        get(dao.savePrivilege(new Privilege("Middle", "m", List.of())));
+        // getPrivileges now uses cache (hasScanned=true) and returns sorted
+        final List<Privilege> privs = get(dao.getPrivileges());
+        assertEquals(privs.size(), 3);
+        assertEquals(privs.get(0).getName(), "Alpha");
+        assertEquals(privs.get(1).getName(), "Middle");
+        assertEquals(privs.get(2).getName(), "Zebra");
+    }
+
+    @Test
+    public void savePrivilegeIsIdempotent() {
+        final Privilege priv = new Privilege("idem-" + RandomData.genAlpha(5), "desc", List.of());
+        get(dao.savePrivilege(priv));
+        get(dao.savePrivilege(priv));
+        assertEquals(get(dao.getPrivilege(priv.getName())), Optional.of(priv));
+    }
+
+    @Test
+    public void clearCacheWorks() {
+        final Privilege priv = new Privilege("clear-" + RandomData.genAlpha(5), "desc", List.of());
+        get(dao.savePrivilege(priv));
+        assertTrue(get(dao.getPrivilege(priv.getName())).isPresent());
+        dao.clearCache();
+        // After clearing, getPrivilege goes to persistence (returns null for non-pass tables)
+        assertTrue(get(dao.getPrivilege(priv.getName())).isEmpty());
+    }
+
+    @Test
+    public void privilegeWithPeopleIsPreserved() {
+        final Person.Id p1 = Person.Id.newInstance();
+        final Person.Id p2 = Person.Id.newInstance();
+        final Privilege priv = new Privilege("withpeople-" + RandomData.genAlpha(5), "desc", List.of(p1, p2));
+        get(dao.savePrivilege(priv));
+        final Privilege found = get(dao.getPrivilege(priv.getName())).orElse(null);
+        assertNotNull(found);
+        assertEquals(found.getPeople().size(), 2);
+        assertTrue(found.getPeople().contains(p1));
+        assertTrue(found.getPeople().contains(p2));
     }
 
     private Privilege getTestPriv() {
@@ -26,5 +116,13 @@ public class PrivilegesDAOTest {
         final Person person1 = FakeData.getFakePeople().get(0);
         final Person person2 = FakeData.getFakePeople().get(1);
         return new Privilege(name, description, List.of(person1.getId(), person2.getId()));
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 }

--- a/trip/src/test/java/org/paulsens/trip/dynamo/RegistrationDAOTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/RegistrationDAOTest.java
@@ -1,0 +1,126 @@
+package org.paulsens.trip.dynamo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.paulsens.trip.model.Person;
+import org.paulsens.trip.model.Registration;
+import org.paulsens.trip.util.RandomData;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class RegistrationDAOTest {
+    private RegistrationDAO dao;
+
+    @BeforeMethod
+    public void setup() {
+        dao = new RegistrationDAO(new ObjectMapper().findAndRegisterModules(), FakeData.createFakePersistence());
+    }
+
+    @Test
+    public void saveAndRetrieveRegistration() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        final Person.Id userId = Person.Id.newInstance();
+        final Registration reg = new Registration(tripId, userId);
+        assertTrue(get(dao.saveRegistration(reg)));
+        final Optional<Registration> found = get(dao.getRegistration(tripId, userId));
+        assertTrue(found.isPresent());
+        assertEquals(found.get().getTripId(), tripId);
+        assertEquals(found.get().getUserId(), userId);
+    }
+
+    @Test
+    public void getRegistrationsReturnsEmptyListForUnknownTrip() {
+        final List<Registration> regs = get(dao.getRegistrations(RandomData.genAlpha(10)));
+        assertTrue(regs.isEmpty());
+    }
+
+    @Test
+    public void getRegistrationReturnsEmptyForUnknownUser() {
+        final String tripId = RandomData.genAlpha(10);
+        final Optional<Registration> result = get(dao.getRegistration(tripId, Person.Id.newInstance()));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void multipleRegistrationsForSameTrip() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        final Person.Id user1 = Person.Id.newInstance();
+        final Person.Id user2 = Person.Id.newInstance();
+        final Person.Id user3 = Person.Id.newInstance();
+        get(dao.saveRegistration(new Registration(tripId, user1)));
+        get(dao.saveRegistration(new Registration(tripId, user2)));
+        get(dao.saveRegistration(new Registration(tripId, user3)));
+        final List<Registration> regs = get(dao.getRegistrations(tripId));
+        assertEquals(regs.size(), 3);
+    }
+
+    @Test
+    public void registrationsForDifferentTripsAreIsolated() throws IOException {
+        final String trip1 = RandomData.genAlpha(10);
+        final String trip2 = RandomData.genAlpha(10);
+        final Person.Id user = Person.Id.newInstance();
+        get(dao.saveRegistration(new Registration(trip1, user)));
+        get(dao.saveRegistration(new Registration(trip2, user)));
+        assertEquals(get(dao.getRegistrations(trip1)).size(), 1);
+        assertEquals(get(dao.getRegistrations(trip2)).size(), 1);
+    }
+
+    @Test
+    public void saveRegistrationIsIdempotent() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        final Person.Id userId = Person.Id.newInstance();
+        final Registration reg = new Registration(tripId, userId);
+        get(dao.saveRegistration(reg));
+        get(dao.saveRegistration(reg));
+        assertEquals(get(dao.getRegistrations(tripId)).size(), 1);
+    }
+
+    @Test
+    public void registrationStatusIsPreserved() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        final Person.Id userId = Person.Id.newInstance();
+        final Registration confirmed = new Registration(tripId, userId).withStatus(Registration.Status.CONFIRMED);
+        get(dao.saveRegistration(confirmed));
+        final Registration retrieved = get(dao.getRegistration(tripId, userId)).orElse(null);
+        assertNotNull(retrieved);
+        assertEquals(retrieved.getStatus(), Registration.Status.CONFIRMED);
+    }
+
+    @Test
+    public void clearCacheWorks() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        get(dao.saveRegistration(new Registration(tripId, Person.Id.newInstance())));
+        assertEquals(get(dao.getRegistrations(tripId)).size(), 1);
+        dao.clearCache();
+        // After clearing, query returns empty from fake persistence
+        assertEquals(get(dao.getRegistrations(tripId)).size(), 0);
+    }
+
+    @Test
+    public void updatingRegistrationReplacesInCache() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        final Person.Id userId = Person.Id.newInstance();
+        get(dao.saveRegistration(new Registration(tripId, userId)));
+        assertEquals(get(dao.getRegistration(tripId, userId)).get().getStatus(), Registration.Status.NOT_REGISTERED);
+        final Registration updated = new Registration(tripId, userId).withStatus(Registration.Status.CONFIRMED);
+        get(dao.saveRegistration(updated));
+        assertEquals(get(dao.getRegistration(tripId, userId)).get().getStatus(), Registration.Status.CONFIRMED);
+        assertEquals(get(dao.getRegistrations(tripId)).size(), 1);
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/trip/src/test/java/org/paulsens/trip/dynamo/TodoDAOTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/TodoDAOTest.java
@@ -1,0 +1,133 @@
+package org.paulsens.trip.dynamo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.paulsens.trip.model.DataId;
+import org.paulsens.trip.model.TodoItem;
+import org.paulsens.trip.util.RandomData;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class TodoDAOTest {
+    private TodoDAO dao;
+
+    @BeforeMethod
+    public void setup() {
+        dao = new TodoDAO(new ObjectMapper().findAndRegisterModules(), FakeData.createFakePersistence());
+    }
+
+    @Test
+    public void saveAndRetrieveTodoItem() throws IOException {
+        final TodoItem todo = TodoItem.builder()
+                .tripId(RandomData.genAlpha(10))
+                .dataId(DataId.newInstance())
+                .description("Buy sunscreen")
+                .build();
+        assertTrue(get(dao.saveTodo(todo)));
+        final Optional<TodoItem> found = get(dao.getTodoItem(todo.getTripId(), todo.getDataId()));
+        assertTrue(found.isPresent());
+        assertEquals(found.get(), todo);
+    }
+
+    @Test
+    public void getTodoItemsReturnsEmptyForUnknownTrip() {
+        assertTrue(get(dao.getTodoItems(RandomData.genAlpha(10))).isEmpty());
+    }
+
+    @Test
+    public void getTodoItemReturnsEmptyForUnknownDataId() {
+        final String tripId = RandomData.genAlpha(10);
+        assertTrue(get(dao.getTodoItem(tripId, DataId.newInstance())).isEmpty());
+    }
+
+    @Test
+    public void multipleTodosForSameTrip() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        for (int i = 0; i < 5; i++) {
+            get(dao.saveTodo(TodoItem.builder()
+                    .tripId(tripId)
+                    .dataId(DataId.newInstance())
+                    .description("Todo " + i)
+                    .build()));
+        }
+        assertEquals(get(dao.getTodoItems(tripId)).size(), 5);
+    }
+
+    @Test
+    public void todosForDifferentTripsAreIsolated() throws IOException {
+        final String trip1 = RandomData.genAlpha(10);
+        final String trip2 = RandomData.genAlpha(10);
+        get(dao.saveTodo(TodoItem.builder().tripId(trip1).dataId(DataId.newInstance()).description("t1").build()));
+        get(dao.saveTodo(TodoItem.builder().tripId(trip1).dataId(DataId.newInstance()).description("t1b").build()));
+        get(dao.saveTodo(TodoItem.builder().tripId(trip2).dataId(DataId.newInstance()).description("t2").build()));
+        assertEquals(get(dao.getTodoItems(trip1)).size(), 2);
+        assertEquals(get(dao.getTodoItems(trip2)).size(), 1);
+    }
+
+    @Test
+    public void saveTodoIsIdempotent() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        final TodoItem todo = TodoItem.builder()
+                .tripId(tripId)
+                .dataId(DataId.newInstance())
+                .description("Idempotent")
+                .build();
+        get(dao.saveTodo(todo));
+        get(dao.saveTodo(todo));
+        assertEquals(get(dao.getTodoItems(tripId)).size(), 1);
+    }
+
+    @Test
+    public void updateTodoReplacesInCache() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        final DataId dataId = DataId.newInstance();
+        final TodoItem original = TodoItem.builder()
+                .tripId(tripId).dataId(dataId).description("Original").build();
+        get(dao.saveTodo(original));
+        assertEquals(get(dao.getTodoItem(tripId, dataId)).get().getDescription(), "Original");
+        final TodoItem updated = TodoItem.builder()
+                .tripId(tripId).dataId(dataId).description("Updated").build();
+        get(dao.saveTodo(updated));
+        assertEquals(get(dao.getTodoItem(tripId, dataId)).get().getDescription(), "Updated");
+    }
+
+    @Test
+    public void clearCacheWorks() throws IOException {
+        final String tripId = RandomData.genAlpha(10);
+        get(dao.saveTodo(TodoItem.builder()
+                .tripId(tripId).dataId(DataId.newInstance()).description("clear me").build()));
+        assertEquals(get(dao.getTodoItems(tripId)).size(), 1);
+        dao.clearCache();
+        assertEquals(get(dao.getTodoItems(tripId)).size(), 0);
+    }
+
+    @Test
+    public void moreDetailsIsPreserved() throws IOException {
+        final TodoItem todo = TodoItem.builder()
+                .tripId(RandomData.genAlpha(10))
+                .dataId(DataId.newInstance())
+                .description("With details")
+                .moreDetails("These are the extra details")
+                .build();
+        get(dao.saveTodo(todo));
+        final TodoItem found = get(dao.getTodoItem(todo.getTripId(), todo.getDataId())).orElse(null);
+        assertNotNull(found);
+        assertEquals(found.getMoreDetails(), "These are the extra details");
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/trip/src/test/java/org/paulsens/trip/dynamo/TransactionDAOTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/TransactionDAOTest.java
@@ -1,17 +1,31 @@
 package org.paulsens.trip.dynamo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.paulsens.trip.model.Person;
 import org.paulsens.trip.model.Transaction;
 import org.paulsens.trip.util.RandomData;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
 public class TransactionDAOTest {
+    private TransactionDAO dao;
+
+    @BeforeMethod
+    public void setup() {
+        dao = new TransactionDAO(new ObjectMapper().findAndRegisterModules(), FakeData.createFakePersistence());
+    }
 
     @Test
     public void testCacheAll() {
@@ -23,15 +37,122 @@ public class TransactionDAOTest {
         txs.add(tx);
         txs.add(tx2);
         final Persistence persistence = new Persistence() {};
-        final TransactionDAO dao = new TransactionDAO(new ObjectMapper(), persistence);
-        final Map<String, Transaction> userTxs = dao.getTxCacheForUser(userId).join();
+        final TransactionDAO localDao = new TransactionDAO(new ObjectMapper(), persistence);
+        final Map<String, Transaction> userTxs = localDao.getTxCacheForUser(userId).join();
         assertEquals(userTxs.size(), 0, "Expected cache to start at 0.");
         persistence.cacheAll(userTxs, txs, Transaction::getTxId);
         assertEquals(userTxs.size(), 2, "Expected cache to add 2 items!");
 
-        final Map<String, Transaction> verifySave = dao.getTxCacheForUser(userId).join();
+        final Map<String, Transaction> verifySave = localDao.getTxCacheForUser(userId).join();
         assertEquals(verifySave.size(), 2, "Expected cache to start at 2 this time!");
         persistence.cacheAll(verifySave, txs, Transaction::getTxId);
         assertEquals(verifySave.size(), 2, "Expected cache to add 2 items!");
+    }
+
+    @Test
+    public void saveAndRetrieveTransaction() throws IOException {
+        final Person.Id userId = Person.Id.newInstance();
+        final Transaction tx = new Transaction(
+                RandomData.genAlpha(8), userId, RandomData.genAlpha(5),
+                Transaction.Type.Tx, Transaction.TransactionType.Payment,
+                LocalDateTime.now(), 100.0f, "food", "lunch");
+        assertTrue(get(dao.saveTransaction(tx)));
+        final Optional<Transaction> found = get(dao.getTransaction(userId, tx.getTxId()));
+        assertTrue(found.isPresent());
+        assertEquals(found.get(), tx);
+    }
+
+    @Test
+    public void getTransactionsReturnsEmptyForUnknownUser() {
+        assertTrue(get(dao.getTransactions(Person.Id.newInstance())).isEmpty());
+    }
+
+    @Test
+    public void getTransactionReturnsEmptyForUnknownTxId() {
+        final Person.Id userId = Person.Id.newInstance();
+        assertTrue(get(dao.getTransaction(userId, "nonexistent")).isEmpty());
+    }
+
+    @Test
+    public void multipleTransactionsForSameUser() throws IOException {
+        final Person.Id userId = Person.Id.newInstance();
+        for (int i = 0; i < 5; i++) {
+            get(dao.saveTransaction(new Transaction(
+                    RandomData.genAlpha(8), userId, RandomData.genAlpha(5),
+                    Transaction.Type.Tx, Transaction.TransactionType.Payment,
+                    LocalDateTime.now().plusMinutes(i), (float) (i * 10), "cat", "note")));
+        }
+        assertEquals(get(dao.getTransactions(userId)).size(), 5);
+    }
+
+    @Test
+    public void transactionsForDifferentUsersAreIsolated() throws IOException {
+        final Person.Id u1 = Person.Id.newInstance();
+        final Person.Id u2 = Person.Id.newInstance();
+        get(dao.saveTransaction(new Transaction(u1, "g1", Transaction.Type.Tx)));
+        get(dao.saveTransaction(new Transaction(u1, "g2", Transaction.Type.Tx)));
+        get(dao.saveTransaction(new Transaction(u2, "g3", Transaction.Type.Tx)));
+        assertEquals(get(dao.getTransactions(u1)).size(), 2);
+        assertEquals(get(dao.getTransactions(u2)).size(), 1);
+    }
+
+    @Test
+    public void saveTransactionIsIdempotent() throws IOException {
+        final Person.Id userId = Person.Id.newInstance();
+        final Transaction tx = new Transaction(
+                "fixed-id", userId, "g1", Transaction.Type.Tx,
+                Transaction.TransactionType.Payment, LocalDateTime.now(), 50f, "cat", "note");
+        get(dao.saveTransaction(tx));
+        get(dao.saveTransaction(tx));
+        assertEquals(get(dao.getTransactions(userId)).size(), 1);
+    }
+
+    @Test
+    public void deletedTransactionIsRemovedFromCache() throws IOException {
+        final Person.Id userId = Person.Id.newInstance();
+        final Transaction tx = new Transaction(
+                RandomData.genAlpha(8), userId, "g1", Transaction.Type.Tx,
+                Transaction.TransactionType.Payment, LocalDateTime.now(), 75f, "cat", "note");
+        get(dao.saveTransaction(tx));
+        assertEquals(get(dao.getTransactions(userId)).size(), 1);
+        tx.delete();
+        get(dao.saveTransaction(tx));
+        assertEquals(get(dao.getTransactions(userId)).size(), 0);
+    }
+
+    @Test
+    public void transactionsAreSortedByDate() throws IOException {
+        final Person.Id userId = Person.Id.newInstance();
+        final LocalDateTime now = LocalDateTime.now();
+        get(dao.saveTransaction(new Transaction(
+                "tx3", userId, "g", Transaction.Type.Tx, Transaction.TransactionType.Payment,
+                now.plusHours(3), 30f, "c", "third")));
+        get(dao.saveTransaction(new Transaction(
+                "tx1", userId, "g", Transaction.Type.Tx, Transaction.TransactionType.Payment,
+                now.plusHours(1), 10f, "c", "first")));
+        get(dao.saveTransaction(new Transaction(
+                "tx2", userId, "g", Transaction.Type.Tx, Transaction.TransactionType.Payment,
+                now.plusHours(2), 20f, "c", "second")));
+        final List<Transaction> txs = get(dao.getTransactions(userId));
+        assertEquals(txs.get(0).getNote(), "first");
+        assertEquals(txs.get(1).getNote(), "second");
+        assertEquals(txs.get(2).getNote(), "third");
+    }
+
+    @Test
+    public void clearCacheWorks() throws IOException {
+        final Person.Id userId = Person.Id.newInstance();
+        get(dao.saveTransaction(new Transaction(userId, "g", Transaction.Type.Tx)));
+        assertEquals(get(dao.getTransactions(userId)).size(), 1);
+        dao.clearCache();
+        assertEquals(get(dao.getTransactions(userId)).size(), 0);
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 }

--- a/trip/src/test/java/org/paulsens/trip/dynamo/TripDAOTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/TripDAOTest.java
@@ -1,0 +1,201 @@
+package org.paulsens.trip.dynamo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.paulsens.trip.model.Trip;
+import org.paulsens.trip.model.TripEvent;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class TripDAOTest {
+    private TripDAO dao;
+    private TripEventDAO tripEventDao;
+
+    @BeforeMethod
+    public void setup() {
+        final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        final Persistence persistence = FakeData.createFakePersistence();
+        tripEventDao = new TripEventDAO(mapper, persistence);
+        dao = new TripDAO(mapper, persistence, tripEventDao);
+    }
+
+    @Test
+    public void saveAndRetrieveTrip() throws IOException {
+        final Trip trip = Trip.builder()
+                .title("Test Trip")
+                .description("A test trip")
+                .startDate(LocalDateTime.now().plusDays(10))
+                .endDate(LocalDateTime.now().plusDays(20))
+                .build();
+        assertTrue(get(dao.saveTrip(trip)));
+        assertEquals(get(dao.getTrip(trip.getId())), Optional.of(trip));
+    }
+
+    @Test
+    public void getTripsReturnsEmptyListInitially() {
+        assertTrue(get(dao.getTrips()).isEmpty());
+    }
+
+    @Test
+    public void getTripWithNullIdReturnsEmpty() {
+        assertEquals(get(dao.getTrip(null)), Optional.empty());
+    }
+
+    @Test
+    public void getTripsReturnsSortedByStartDate() throws IOException {
+        final Trip later = Trip.builder()
+                .title("Later")
+                .startDate(LocalDateTime.now().plusDays(30))
+                .build();
+        final Trip earlier = Trip.builder()
+                .title("Earlier")
+                .startDate(LocalDateTime.now().plusDays(5))
+                .build();
+        final Trip middle = Trip.builder()
+                .title("Middle")
+                .startDate(LocalDateTime.now().plusDays(15))
+                .build();
+        get(dao.saveTrip(later));
+        get(dao.saveTrip(earlier));
+        get(dao.saveTrip(middle));
+        final List<Trip> trips = get(dao.getTrips());
+        assertEquals(trips.size(), 3);
+        assertEquals(trips.get(0).getTitle(), "Earlier");
+        assertEquals(trips.get(1).getTitle(), "Middle");
+        assertEquals(trips.get(2).getTitle(), "Later");
+    }
+
+    @Test
+    public void saveTripIsIdempotent() throws IOException {
+        final Trip trip = Trip.builder().title("Idempotent").build();
+        get(dao.saveTrip(trip));
+        get(dao.saveTrip(trip));
+        assertEquals(get(dao.getTrips()).size(), 1);
+    }
+
+    @Test
+    public void saveTripAlsoSavesTripEvents() throws IOException {
+        final TripEvent te = new TripEvent(UUID.randomUUID().toString(), TripEvent.Type.FLIGHT,
+                "Test Flight", "notes", LocalDateTime.now(), null, null, null);
+        final Trip trip = Trip.builder()
+                .title("With Events")
+                .tripEvents(List.of(te))
+                .build();
+        get(dao.saveTrip(trip));
+        // The trip event should be saved in the TripEventDAO
+        final TripEvent retrieved = get(tripEventDao.getTripEvent(te.getId()));
+        assertEquals(retrieved, te);
+    }
+
+    @Test
+    public void clearCacheWorks() throws IOException {
+        final Trip trip = Trip.builder().title("Cache Test").build();
+        get(dao.saveTrip(trip));
+        assertEquals(get(dao.getTrips()).size(), 1);
+        dao.clearCache();
+        // After clear, scan returns empty (fake persistence)
+        assertEquals(get(dao.getTrips()).size(), 0);
+    }
+
+    @Test
+    public void getTripServesFromCache() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        final Trip trip = Trip.builder().title("Cached Trip").startDate(LocalDateTime.now().plusDays(10)).build();
+        final AtomicInteger scanCount = new AtomicInteger(0);
+        final Persistence countingPersistence = new Persistence() {
+            @Override
+            public CompletableFuture<ScanResponse> scan(Consumer<ScanRequest.Builder> scanRequest) {
+                scanCount.incrementAndGet();
+                try {
+                    return CompletableFuture.completedFuture(ScanResponse.builder().items(List.of(
+                            Map.of("id", toStrAttr(trip.getId()),
+                                    "content", toStrAttr(mapper.writeValueAsString(trip)))
+                    )).build());
+                } catch (final IOException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        };
+        final TripDAO countingDao = new TripDAO(mapper, countingPersistence,
+                new TripEventDAO(mapper, countingPersistence));
+        // First call triggers a scan
+        final List<Trip> trips = get(countingDao.getTrips());
+        assertEquals(trips.size(), 1);
+        assertEquals(scanCount.get(), 1, "First call should scan");
+        // Second call should serve from cache
+        final Optional<Trip> cached = get(countingDao.getTrip(trip.getId()));
+        assertTrue(cached.isPresent());
+        assertEquals(scanCount.get(), 1, "Second call should use cache, not scan again");
+    }
+
+    @Test
+    public void getTripLoadsAllTripsOnCacheMiss() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        final Trip tripA = Trip.builder().id("tripA").title("Trip A").startDate(LocalDateTime.now().plusDays(5)).build();
+        final Trip tripB = Trip.builder().id("tripB").title("Trip B").startDate(LocalDateTime.now().plusDays(10)).build();
+        final AtomicInteger scanCount = new AtomicInteger(0);
+        final Persistence countingPersistence = new Persistence() {
+            @Override
+            public CompletableFuture<ScanResponse> scan(Consumer<ScanRequest.Builder> scanRequest) {
+                scanCount.incrementAndGet();
+                try {
+                    return CompletableFuture.completedFuture(ScanResponse.builder().items(List.of(
+                            Map.of("id", toStrAttr("tripA"),
+                                    "content", toStrAttr(mapper.writeValueAsString(tripA))),
+                            Map.of("id", toStrAttr("tripB"),
+                                    "content", toStrAttr(mapper.writeValueAsString(tripB)))
+                    )).build());
+                } catch (final IOException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        };
+        final TripDAO countingDao = new TripDAO(mapper, countingPersistence,
+                new TripEventDAO(mapper, countingPersistence));
+        // Cache is empty. Request tripA — this should trigger getTrips(), loading both trips.
+        final Optional<Trip> foundA = get(countingDao.getTrip("tripA"));
+        assertTrue(foundA.isPresent());
+        assertEquals(foundA.get().getTitle(), "Trip A");
+        assertEquals(scanCount.get(), 1, "Should have scanned exactly once");
+        // tripB should also be in cache — no additional scan needed
+        final Optional<Trip> foundB = get(countingDao.getTrip("tripB"));
+        assertTrue(foundB.isPresent());
+        assertEquals(foundB.get().getTitle(), "Trip B");
+        assertEquals(scanCount.get(), 1, "Should still be 1 — tripB was loaded by the first scan");
+    }
+
+    @Test
+    public void multipleTripsCanBeStored() throws IOException {
+        for (int i = 0; i < 5; i++) {
+            final Trip trip = Trip.builder()
+                    .title("Trip " + i)
+                    .startDate(LocalDateTime.now().plusDays(i))
+                    .build();
+            get(dao.saveTrip(trip));
+        }
+        assertEquals(get(dao.getTrips()).size(), 5);
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/trip/src/test/java/org/paulsens/trip/dynamo/TripEventDAOTest.java
+++ b/trip/src/test/java/org/paulsens/trip/dynamo/TripEventDAOTest.java
@@ -1,0 +1,134 @@
+package org.paulsens.trip.dynamo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.paulsens.trip.model.Trip;
+import org.paulsens.trip.model.TripEvent;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class TripEventDAOTest {
+    private TripEventDAO dao;
+
+    @BeforeMethod
+    public void setup() {
+        dao = new TripEventDAO(new ObjectMapper().findAndRegisterModules(), FakeData.createFakePersistence());
+    }
+
+    @Test
+    public void saveAndRetrieveTripEvent() {
+        final TripEvent te = new TripEvent(UUID.randomUUID().toString(), TripEvent.Type.FLIGHT,
+                "PDX -> JFK", "Red eye flight", LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(11),
+                null, null);
+        assertTrue(get(dao.saveTripEvent(te)));
+        final TripEvent retrieved = get(dao.getTripEvent(te.getId()));
+        assertEquals(retrieved, te);
+    }
+
+    @Test
+    public void getTripEventReturnsNullForUnknownId() {
+        // Fake persistence returns null item for getItem on non-pass tables
+        final TripEvent result = get(dao.getTripEvent("nonexistent-id"));
+        assertNull(result);
+    }
+
+    @Test
+    public void getTripEventServesFromCache() {
+        final AtomicInteger getItemCount = new AtomicInteger(0);
+        final Persistence countingPersistence = new Persistence() {
+            @Override
+            public CompletableFuture<GetItemResponse> getItem(Consumer<GetItemRequest.Builder> getItemRequest) {
+                getItemCount.incrementAndGet();
+                return Persistence.super.getItem(getItemRequest);
+            }
+        };
+        final TripEventDAO countingDao = new TripEventDAO(
+                new ObjectMapper().findAndRegisterModules(), countingPersistence);
+        final TripEvent te = new TripEvent(UUID.randomUUID().toString(), TripEvent.Type.LODGING,
+                "Hotel", "Nice place", LocalDateTime.now(), LocalDateTime.now().plusDays(3), null, null);
+        get(countingDao.saveTripEvent(te));
+        assertEquals(getItemCount.get(), 0, "Save should not call getItem");
+        // Retrieve should come from cache, not from persistence.getItem
+        final TripEvent cached = get(countingDao.getTripEvent(te.getId()));
+        assertEquals(cached, te);
+        assertEquals(getItemCount.get(), 0, "getTripEvent should serve from cache, not call getItem");
+    }
+
+    @Test
+    public void saveAllTripEventsForTrip() {
+        final TripEvent te1 = new TripEvent(UUID.randomUUID().toString(), TripEvent.Type.FLIGHT,
+                "Flight 1", "notes", LocalDateTime.now(), null, null, null);
+        final TripEvent te2 = new TripEvent(UUID.randomUUID().toString(), TripEvent.Type.LODGING,
+                "Hotel", "notes", LocalDateTime.now().plusDays(1), null, null, null);
+        final Trip trip = Trip.builder()
+                .title("Test Trip")
+                .tripEvents(List.of(te1, te2))
+                .build();
+        assertTrue(get(dao.saveAllTripEvents(trip)));
+        assertEquals(get(dao.getTripEvent(te1.getId())), te1);
+        assertEquals(get(dao.getTripEvent(te2.getId())), te2);
+    }
+
+    @Test
+    public void saveAllTripEventsWithEmptyList() {
+        final Trip trip = Trip.builder()
+                .title("Empty Trip")
+                .tripEvents(Collections.emptyList())
+                .build();
+        assertTrue(get(dao.saveAllTripEvents(trip)));
+    }
+
+    @Test
+    public void clearCacheWorks() {
+        final TripEvent te = new TripEvent(UUID.randomUUID().toString(), TripEvent.Type.EVENT,
+                "Concert", "notes", LocalDateTime.now(), null, null, null);
+        get(dao.saveTripEvent(te));
+        assertEquals(get(dao.getTripEvent(te.getId())), te);
+        dao.clearCache();
+        // After clearing, fetching again goes to persistence (returns null for non-pass tables)
+        assertNull(get(dao.getTripEvent(te.getId())));
+    }
+
+    @Test
+    public void saveTripEventIsIdempotent() {
+        final TripEvent te = new TripEvent(UUID.randomUUID().toString(), TripEvent.Type.GROUND,
+                "Bus ride", "notes", LocalDateTime.now(), null, null, null);
+        assertTrue(get(dao.saveTripEvent(te)));
+        assertTrue(get(dao.saveTripEvent(te)));
+        assertEquals(get(dao.getTripEvent(te.getId())), te);
+    }
+
+    @Test
+    public void saveTripEventUpdatesCache() {
+        final String id = UUID.randomUUID().toString();
+        final TripEvent original = new TripEvent(id, TripEvent.Type.FLIGHT,
+                "Original", "notes", LocalDateTime.now(), null, null, null);
+        get(dao.saveTripEvent(original));
+        assertEquals(get(dao.getTripEvent(id)).getTitle(), "Original");
+        final TripEvent updated = new TripEvent(id, TripEvent.Type.FLIGHT,
+                "Updated", "new notes", LocalDateTime.now(), null, null, null);
+        get(dao.saveTripEvent(updated));
+        assertEquals(get(dao.getTripEvent(id)).getTitle(), "Updated");
+    }
+
+    private <T> T get(final CompletableFuture<T> future) {
+        try {
+            return future.get(1_000, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException | ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 7 new test files for previously untested DAO classes: `PersonDAO`, `TripDAO`, `TripEventDAO`, `RegistrationDAO`, `TodoDAO`, `PersonDataValueDAO`, `CredentialsDAO`
- Adds tests for the `Persistence` interface default methods and `FakeData` utilities
- Expands existing `TransactionDAOTest` and `PrivilegesDAOTest` with additional coverage
- All tests use `FakeData.createFakePersistence()` for isolation (no AWS dependency)
- Total: 131 new tests across 11 files (314 total tests, all passing)

## Test plan
- [x] All 314 tests pass via `mvn test -pl trip`
- [x] No changes to production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)